### PR TITLE
Bump gradle and NDK

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Sep 26 02:13:18 PDT 2021
+#Wed Apr 24 19:18:08 EEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/module/build.gradle
+++ b/module/build.gradle
@@ -18,7 +18,7 @@ android {
             abiFilters "arm64-v8a", "armeabi-v7a", "x86", "x86_64"
         }
     }
-    ndkVersion '22.1.7171670'
+    ndkVersion '26.2.11394342'
 }
 
 cargo {


### PR DESCRIPTION
Greetings! I had some issues with this, here's some fixes:

Firsly, you will see something like: `General error during conversion: Unsupported class file major version 61`. **Fixed with gradle bump**
Then, you will see `Task :module:cargoBuildArm64 FAILED` due `ld: error: unable to find library -lunwind`. **Fixed with NDK bump**